### PR TITLE
Add preamble at the top of the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
     <link rel="stylesheet" href="https://cdn.simplecss.org/simple.css">
 </head>
 <body>
+<div>
+    <h1>Metalinguistic NLP Bibliography</h1>
+    <p>The following (running) bibliography collates works in Metalinguistic NLP, including (linguistic) metalanguage.
+        We do not update it at fixed frequency so the Github repository <a href="https://github.com/nert-nlp/metalinguistic-nlp-bib/issues?q=is%3Aissue%20state%3Aopen%20label%3Aentry">issues</a> can be checked for things under consideration.
+    <p>The bibliography is maintained by <a href="https://abhishek-p.github.io/">Abhishek Purushothama</a> and <a href="http://nathan.cl">Prof. Nathan Schneider</a>. It emulates
+    <a href="https://nert-nlp.github.io/AMR-Bibliography/">AMR Bibliography</a> &amp; <a href="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vR294DXq1IrdXw3rfOcv2RoG7ofISF0Xs4LDekIzSWTug8b4fvkbLnOl4X5L7Vo-7GFqvVwFq0y_Hxb/pubhtml">CxG+NLP</a> bibliographies.
+    </p>
+</div>
+
 <script src="https://bibbase.org/show?bib=http://nert-nlp.github.io/metalinguistic-nlp-bib/nmlp.bib&jsonp=1"></script>
+<hr/>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <h1>Metalinguistic NLP Bibliography</h1>
     <p>The following (running) bibliography collates works in Metalinguistic NLP, including (linguistic) metalanguage.
         We do not update it at fixed frequency so the Github repository <a href="https://github.com/nert-nlp/metalinguistic-nlp-bib/issues?q=is%3Aissue%20state%3Aopen%20label%3Aentry">issues</a> can be checked for things under consideration.
-    <p>The bibliography is maintained by <a href="https://abhishek-p.github.io/">Abhishek Purushothama</a> and <a href="http://nathan.cl">Prof. Nathan Schneider</a>. It emulates
-    <a href="https://nert-nlp.github.io/AMR-Bibliography/">AMR Bibliography</a> &amp; <a href="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vR294DXq1IrdXw3rfOcv2RoG7ofISF0Xs4LDekIzSWTug8b4fvkbLnOl4X5L7Vo-7GFqvVwFq0y_Hxb/pubhtml">CxG+NLP</a> bibliographies.
+    <p>The bibliography is maintained by <a href="https://abhishek-p.github.io/">Abhishek Purushothama</a> and <a href="http://nathan.cl">Prof. Nathan Schneider</a>. 
+        Other bibliographies from the lab : <a href="https://nert-nlp.github.io/AMR-Bibliography/">AMR Bibliography</a> &amp; <a href="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vR294DXq1IrdXw3rfOcv2RoG7ofISF0Xs4LDekIzSWTug8b4fvkbLnOl4X5L7Vo-7GFqvVwFq0y_Hxb/pubhtml">CxG+NLP</a> bibliographies.
     </p>
 </div>
 


### PR DESCRIPTION
Adds a preamble at the top of the page
Similar to Readme but mentions the maintainers and links to websites.